### PR TITLE
Fix: 500 error on clicking view agent button

### DIFF
--- a/resources/views/agents/show.blade.php
+++ b/resources/views/agents/show.blade.php
@@ -59,7 +59,7 @@
             </div>
         @endif
 
-        @if($agent->tools->count() > 0)
+        @if($agent->tools?->count() > 0)
             <div class="mb-4">
                 <h3 class="text-lg font-semibold text-gray-900 mb-2">Tools</h3>
                 <ul class="list-disc list-inside">

--- a/tests/Unit/Models/AiAgentTest.php
+++ b/tests/Unit/Models/AiAgentTest.php
@@ -25,6 +25,20 @@ class AiAgentTest extends TestCase
         ]);
     }
 
+    public function test_agent_can_be_viewed()
+    {
+        $agent = AiAgent::create([
+            'name' => 'Test Agent',
+            'slug' => 'test-agent',
+            'provider' => 'openai',
+            'is_active' => true,
+        ]);
+
+        $response = $this->get(route('chatbot.agents.show', $agent));
+        $response->assertStatus(200);
+        $response->assertSee('Test Agent');
+    }
+
     public function test_slug_is_auto_generated_from_name()
     {
         $agent = AiAgent::create([


### PR DESCRIPTION
## Description
Added Nullsafe Operator to check if tools exist before checking the tools count. This fixes the 500 error on agent view page.

## Related Issue
- https://github.com/saurabhshukla-developer/laravel-ai-chatbot/issues/1

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [ ] My code follows the code style of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Testing
`vendor/bin/phpunit --filter=test_agent_can_be_viewed`

## Screenshots (if applicable)
`vendor/bin/phpunit --filter=test_agent_can_be_viewed`

<img width="1669" height="562" alt="image" src="https://github.com/user-attachments/assets/be04a205-781c-4722-83a4-d1156211b2cf" />

`vendor/bin/phpunit`

<img width="1495" height="1425" alt="image" src="https://github.com/user-attachments/assets/14fe1083-a719-440b-830b-89fc1866f43d" />


